### PR TITLE
Fix the loot table for the Decorative Skeleton

### DIFF
--- a/src/main/resources/data/graveyard/loot_table/blocks/bone_remains.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/bone_remains.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/creeper_skeleton.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/creeper_skeleton.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/hanged_skeleton.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/hanged_skeleton.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/hanged_wither_skeleton.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/hanged_wither_skeleton.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/laterally_lying_skeleton.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/laterally_lying_skeleton.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/laterally_lying_wither_skeleton.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/laterally_lying_wither_skeleton.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/leaning_skeleton.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/leaning_skeleton.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/leaning_wither_skeleton.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/leaning_wither_skeleton.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/lying_skeleton.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/lying_skeleton.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/lying_wither_skeleton.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/lying_wither_skeleton.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/skeleton_hand.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/skeleton_hand.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/skull_on_pike.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/skull_on_pike.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/skull_pile.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/skull_pile.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/skull_with_rib_cage.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/skull_with_rib_cage.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/torso_pile.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/torso_pile.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/wither_bone_remains.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/wither_bone_remains.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/wither_skeleton_hand.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/wither_skeleton_hand.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/wither_skull_on_pike.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/wither_skull_on_pike.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/wither_skull_pile.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/wither_skull_pile.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/wither_skull_with_rib_cage.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/wither_skull_with_rib_cage.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],

--- a/src/main/resources/data/graveyard/loot_table/blocks/wither_torso_pile.json
+++ b/src/main/resources/data/graveyard/loot_table/blocks/wither_torso_pile.json
@@ -14,14 +14,16 @@
                 {
                   "condition": "minecraft:match_tool",
                   "predicate": {
-                    "enchantments": [
-                      {
-                        "enchantment": "minecraft:silk_touch",
-                        "levels": {
-                          "min": 1
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
                         }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               ],


### PR DESCRIPTION
现在破坏装饰性骷髅后会正常掉落4个骨头。
另外，Vase/陶瓷 除了装饰貌似啥用没有……

> https://github.com/MapleSugar365/the-graveyard-1.21-fix/blob/1.21.1-neoforge/src/main/resources/data/graveyard/loot_table/chests/vase_loot.json

根据这个文件来看，我猜原作者是打算做成：左键破坏后随机从战利品表里爆物品。